### PR TITLE
Fix date format of take-part event list

### DIFF
--- a/lib/take-part.js
+++ b/lib/take-part.js
@@ -17,7 +17,7 @@ import {
 } from './city';
 import { fetchLink } from './link';
 
-import { buildGraphQLQuery } from '@/lib/actions';
+import { buildGraphQLQuery, formatTime } from '@/lib/actions';
 import { getFragments, sideloadBlockData } from '@/components/Blocks';
 import FRAGMENT_SAFE_HARBOURS from '@/components/Demands/SafeHarbour/fragment';
 import FRAGMENT_MEDIA from '@/components/Media/fragment';
@@ -361,6 +361,14 @@ async function fetchGroup(citySlug, locale, formatting, options) {
   const { actions } = await fetchAPI(actionsQuery, options);
 
   city.group.actions = actions || [];
+
+  city.group.actions = actions.map(({ coordinates, start, end, ...action }) => ({
+    ...action,
+    start: formatTime(start, formatting.dateTime),
+    end: formatTime(end, formatting.dateTime),
+    coordinates: toMapboxCoordinates(coordinates)
+  }));
+
   city.group = await sideloadBlockData(
     city.group,
     'content',


### PR DESCRIPTION
Fixes wrong date format on take-part sites with events.

Before:
![Screenshot 2023-01-22 at 09-59-21 Lokalgruppe Braunschweig Seebrücke](https://user-images.githubusercontent.com/10660618/213908054-cc3a9bd4-d933-43fa-b110-87b1c0fc3b03.png)

After:
![Screenshot 2023-01-22 at 09-59-41 Lokalgruppe Braunschweig Seebrücke](https://user-images.githubusercontent.com/10660618/213908055-ff205950-5aff-46ff-80c5-357340802ae5.png)
