### PR TITLE
Fix newsletter, donation form, section-nav & markdown line-break regressions

### DIFF
--- a/components/Fundraisingbox/Fundraisingbox.js
+++ b/components/Fundraisingbox/Fundraisingbox.js
@@ -1,21 +1,43 @@
 import { useTranslation } from 'next-i18next';
 import { useEffect, useRef } from 'react';
 
+const SCRIPT_ID = 'fundraisingbox-script';
+
 export default function Fundraisingbox({ scriptUrl }) {
   const { t } = useTranslation();
 
-  const scriptRoot = useRef(); // gets assigned to a root node
-  const script = `<script type='text/javascript' src=${scriptUrl} ></script>`;
+  const scriptRoot = useRef(); // gets assigned to the root node the widget injects into
 
   useEffect(() => {
-    // creates a document range (grouping of nodes in the document is my understanding)
-    // in this case we instantiate it as empty, on purpose
-    const range = document.createRange();
-    // creates a mini-document (light weight version), in our range with our script in it
-    const documentFragment = range.createContextualFragment(script);
-    // appends it to our script root - so it renders in the correct location
-    scriptRoot.current.append(documentFragment);
-  });
+    if (!scriptUrl || !scriptRoot.current) {
+      return undefined;
+    }
+
+    // Only ever inject the widget once. Without this guard the script was
+    // re-appended on every render (e.g. on menu changes), which loaded the
+    // box multiple times and could leave it failing to initialise.
+    if (document.getElementById(SCRIPT_ID)) {
+      return undefined;
+    }
+
+    const script = document.createElement('script');
+    script.id = SCRIPT_ID;
+    script.type = 'text/javascript';
+    script.src = scriptUrl;
+    script.async = true;
+    script.onerror = () => {
+      console.error(
+        '[Fundraisingbox] failed to load widget script:',
+        scriptUrl
+      );
+    };
+
+    scriptRoot.current.append(script);
+
+    return () => {
+      script.remove();
+    };
+  }, [scriptUrl]);
 
   return (
     <div>

--- a/components/Markdown/Markdown.js
+++ b/components/Markdown/Markdown.js
@@ -1,5 +1,12 @@
 import ReactMarkdown from 'react-markdown';
+import breaks from 'remark-breaks';
 
-export default function Markdown({ children, ...props }) {
-  return <ReactMarkdown {...props}>{children}</ReactMarkdown>;
+export default function Markdown({ children, plugins = [], ...props }) {
+  // `remark-breaks` turns a single newline (one Enter in Strapi) into a <br>,
+  // so line breaks entered by editors show up on the site.
+  return (
+    <ReactMarkdown plugins={[breaks, ...plugins]} {...props}>
+      {children}
+    </ReactMarkdown>
+  );
 }

--- a/components/Newsletter/Newsletter.js
+++ b/components/Newsletter/Newsletter.js
@@ -1,6 +1,5 @@
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'next-i18next';
-import { getFullClientUrl } from '@/lib/url';
 import Form from '@/components/Form';
 import Button from '@/components/Form/Button';
 import Checkbox from '@/components/Form/Checkbox';
@@ -14,20 +13,24 @@ export default function Newsletter({ title, intro }) {
   });
   const { t } = useTranslation();
   const onSubmit = async function (data) {
-    const result = await fetch(getFullClientUrl('/api/newsletter/subscribe'), {
-      method: 'post',
-      body: JSON.stringify(data),
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    });
-
     const toast = (await import('react-hot-toast')).default;
 
-    if (result.ok) {
-      toast.success(t('newsletter.form.success'));
-      reset();
-    } else {
+    try {
+      const result = await fetch('/api/newsletter/subscribe', {
+        method: 'post',
+        body: JSON.stringify(data),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+
+      if (result.ok) {
+        toast.success(t('newsletter.form.success'));
+        reset();
+      } else {
+        toast.error(t('newsletter.form.error'));
+      }
+    } catch (err) {
       toast.error(t('newsletter.form.error'));
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "react-social-media-embed": "^2.3.5",
         "react-ssr-prepass": "npm:preact-ssr-prepass@^1.2.0",
         "remark": "^14.0.2",
+        "remark-breaks": "^2.0.2",
         "remark-excerpt": "^1.0.0-beta.1",
         "remark-extract-toc": "^1.1.0",
         "remark-parse": "^10.0.1",
@@ -18906,6 +18907,18 @@
         "remark-parse": "^10.0.0",
         "remark-stringify": "^10.0.0",
         "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-2.0.2.tgz",
+      "integrity": "sha512-LsQnPPQ7Fzp9RTjj4IwdEmjPOr9bxe9zYKWhs9ZQOg9hMg8rOfeeqQ410cvVdIK87Famqza1CKRxNkepp2EvUA==",
+      "dependencies": {
+        "unist-util-visit": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-social-media-embed": "^2.3.5",
     "react-ssr-prepass": "npm:preact-ssr-prepass@^1.2.0",
     "remark": "^14.0.2",
+    "remark-breaks": "^2.0.2",
     "remark-excerpt": "^1.0.0-beta.1",
     "remark-extract-toc": "^1.1.0",
     "remark-parse": "^10.0.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -13,7 +13,7 @@ import FacebookPixel from '@/components/FacebookPixel';
 
 import '@/styles/tailwind.css';
 import '@/styles/spende.css';
-import 'swiper/bundle';
+import 'swiper/swiper-bundle.css';
 
 const CookieConsent = dynamic(() => import('react-cookie-consent'), {
   ssr: false

--- a/pages/api/newsletter/subscribe.js
+++ b/pages/api/newsletter/subscribe.js
@@ -26,14 +26,21 @@ export default async function handler(req, res) {
 
     return res.json({});
   } catch (err) {
-    let message = {
-      error: 'Something went wrong'
-    };
+    const body = err?.response?.body;
 
-    if (process.env.NODE_ENV !== 'production') {
-      message = err.response.body;
+    // Log the real cause so production failures are diagnosable.
+    console.error('[newsletter/subscribe] Mailchimp error:', body || err);
+
+    // An already-subscribed address is not a real error for the user.
+    if (body?.title === 'Member Exists') {
+      return res.json({});
     }
 
-    return res.status(err.status || 400).json(message);
+    const message =
+      process.env.NODE_ENV !== 'production' && body
+        ? body
+        : { error: 'Something went wrong' };
+
+    return res.status(err?.status || 400).json(message);
   }
 }


### PR DESCRIPTION
Fixes four reported issues, several affecting iOS Safari.

## 1. Section navigation stacked vertically (definitive fix) ✅
`pages/_app.js`

Commit `cc6e8ed` ("make tracking at least gdpr compliant") accidentally changed the Swiper import from the **stylesheet** to the **JS bundle**:

```diff
-import 'swiper/swiper-bundle.css';
+import 'swiper/bundle';
```

Swiper's JS still initialised (so the markup looked right), but without its CSS the `.swiper-wrapper` lost `display: flex`, so the slides fell back to vertical block stacking. The JS is already imported by the components via `swiper/react`, so this line only needs to provide the CSS. Restored it. Affects every `SectionNavigation` on the site (e.g. the `/spenden` sub-nav).

## 2. Markdown line breaks no longer showing (definitive fix) ✅
`components/Markdown/Markdown.js` (+ `remark-breaks` dependency)

Editors enter line breaks in Strapi (a single newline), but by Markdown rules a single newline collapses to a space, so the breaks disappeared on the site. Added the `remark-breaks` plugin (pinned to `^2.0.2` for `react-markdown@5` / unified 9 compatibility — v3+ is ESM and breaks the build) wired into the shared `Markdown` component, so all CMS rich text honours single newlines.

Verified: `"a\nb"` now renders as `a<br/>b` instead of `a b`.

## 3. Newsletter signup failing (esp. iOS Safari)
`components/Newsletter/Newsletter.js`, `pages/api/newsletter/subscribe.js`

- The form fetched an **absolute URL** built from `NEXT_PUBLIC_FRONTEND_DOMAIN`, which is fragile (missing scheme, cross-origin → blocked by iOS WebKit, history of misconfiguration). Switched to a **same-origin relative path** `/api/newsletter/subscribe`.
- Wrapped the fetch in `try/catch` so network failures surface a user-facing error instead of throwing.
- API route now **logs the real Mailchimp error** (previously hidden in production behind "Something went wrong"), safe-accesses `err.response.body`, and treats "Member Exists" as success for already-subscribed users.

⚠️ The relative-URL change makes the form correct regardless of the prod env value. If failures persist, the new server log will reveal the actual Mailchimp cause. Needs verification on a real iPhone.

## 4. Donation form not loading (esp. iOS Safari)
`components/Fundraisingbox/Fundraisingbox.js`

Replaced the hand-rolled `createContextualFragment` injection (which ran on **every render** with no dependency array, re-loading the widget on menu changes) with a guarded `createElement` approach matching the existing Twitter embed: inject the script **once** via an id-based dedup guard, add an `onerror` fallback, and run only when `scriptUrl` changes with cleanup on unmount.

⚠️ This hardens our embed but may not fully resolve the iOS failure if the root cause is Safari's **Prevent Cross-Site Tracking** blocking the third-party `fundraisingbox.com` iframe. Needs device verification.

## Verification checklist
- [ ] Section nav renders horizontally (all browsers)
- [ ] CMS line breaks (single newline in Strapi) now render on the site
- [ ] Newsletter signup works on a real iPhone; if not, check server logs for the Mailchimp error
- [ ] Confirm prod `NEXT_PUBLIC_FRONTEND_DOMAIN` value
- [ ] Donation form loads on a real iPhone; test with "Prevent Cross-Site Tracking" off to isolate ITP

## Not included
- Font-size consistency across `/spenden/*` vs `meta-a/b`, `foerdern-nl`, `brief-spenden` — pending a direction decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)